### PR TITLE
Support using same key for signing and encrypting

### DIFF
--- a/private_key.v
+++ b/private_key.v
@@ -26,6 +26,18 @@ pub fn new_private_key() PrivateKey {
 	return pk
 }
 
+pub fn new_private_key_from_signing_ed25519(s SigningKey) PrivateKey {
+	mut pk := PrivateKey{
+		public_key: []u8{len: public_key_size}
+		secret_key: []u8{len: secret_key_size}
+	}
+
+	crypto_sign_ed25519_pk_to_curve25519(pk.public_key.data, s.verify_key.public_key[0])
+	crypto_sign_ed25519_sk_to_curve25519(pk.secret_key.data, s.secret_key[0])
+
+	return pk
+}
+
 pub fn crypto_kx_seed_keypair(seed []u8) PrivateKey {
 	mut pk := PrivateKey{
 		public_key: []u8{len: public_key_size}

--- a/sign.v
+++ b/sign.v
@@ -10,7 +10,8 @@ pub:
 	verify_key VerifyKey
 }
 
-struct VerifyKey {
+pub struct VerifyKey {
+pub:
 	public_key [public_key_size]u8
 }
 

--- a/sign.v
+++ b/sign.v
@@ -23,10 +23,43 @@ pub fn new_signing_key(public_key [public_key_size]u8, secret_key [secret_key_si
 	return res
 }
 
+pub fn generate_ed25519_signing_key() SigningKey {
+	mut pk := SigningKey{
+		secret_key: [secret_key_size]u8{}
+		verify_key: VerifyKey{
+			public_key: [public_key_size]u8{}
+		}
+	}
+
+	x := crypto_sign_ed25519_keypair(pk.verify_key.public_key[0], pk.secret_key[0])
+
+	if x != 0 {
+		// TODO handle errors
+	}
+	return pk
+}
+
 pub fn generate_signing_key() SigningKey {
 	res := SigningKey{}
 	C.crypto_sign_keypair(&res.verify_key.public_key[0], &res.secret_key[0])
 	return res
+}
+
+pub fn new_ed25519_signing_key_seed(seed []u8) SigningKey {
+	mut pk := SigningKey{
+		secret_key: [secret_key_size]u8{}
+		verify_key: VerifyKey{
+			public_key: [public_key_size]u8{}
+		}
+	}
+
+	x := crypto_sign_ed25519_seed_keypair(pk.verify_key.public_key[0], pk.secret_key[0],
+		seed.data)
+
+	if x != 0 {
+		// TODO handle errors
+	}
+	return pk
 }
 
 pub fn new_signing_key_seed(seed []u8) SigningKey {

--- a/sign.v
+++ b/sign.v
@@ -4,7 +4,7 @@ const (
 	sign_len = 64
 )
 
-struct SigningKey {
+pub struct SigningKey {
 	secret_key [secret_key_size]u8
 pub:
 	verify_key VerifyKey


### PR DESCRIPTION
Using `crypto_sign_ed25519_pk_to_curve25519`and `crypto_sign_ed25519_sk_to_curve25519` it's possible to use the same key for signing and encrypting. This pull request add some helpers around this.