### PR TITLE
allow to access `SecretBox.nonce`

### DIFF
--- a/secret_box.v
+++ b/secret_box.v
@@ -9,9 +9,10 @@ pub const (
 )
 
 pub struct SecretBox {
-	nonce [24]u8
 mut:
 	key [32]u8
+pub:
+	nonce [24]u8
 }
 
 pub fn new_secret_box(key string) SecretBox {


### PR DESCRIPTION
The change allows to use the nonce of a Secretbox for en- and decryption.